### PR TITLE
Add world coords support

### DIFF
--- a/tools/fusion360gym/README.md
+++ b/tools/fusion360gym/README.md
@@ -92,13 +92,13 @@ Note that when returning binary data (e.g. mesh, brep) the above keys will not b
     - Returns the `sketch_name` and `sketch_id`.
 - `add_point(sketch_name, p1, transform)`: Add a point to create a new sequential line in the given sketch
     - `sketch_name`: is the string name of the sketch returned by `add_sketch()`
-    - `p1`: a point in sketch space 2D coords in a dict e.g. `{"x": 0, "y": 0}`
-    - `transform` (optional): the transform for the sketch, necessary if you are replaying json data exported from Fusion
+    - `p1`: a point in sketch space 2D coords in a dict e.g. `{"x": 0, "y": 0}` or 3D coords if `transform="world"` is specified, indicating use of world coords
+    - `transform` (optional): the transform for the sketch (necessary if you are replaying json data exported from Fusion) or a string `world` denoting use of world coordinates.
     - Returns the sketch `profiles` or an empty dict if there are no `profiles`. Note that profile uuid returned is only valid while the design does not change.
 - `add_line(sketch_name, p1, p2, transform)`: Adds a line to the given sketch. 
     - `sketch_name`: is the string name of the sketch returned by `add_sketch()`
-    - `p1` and `p2`: are sketch space 2D coords of the line in a dict e.g. `{"x": 0, "y": 0}`
-    - `transform` (optional): the transform for the sketch, necessary if you are replaying json data exported from Fusion
+    - `p1` and `p2`: are sketch space 2D coords of the line in a dict e.g. `{"x": 0, "y": 0}` or 3D coords if `transform="world"` is specified, indicating use of world coords
+    - `transform` (optional): the transform for the sketch (necessary if you are replaying json data exported from Fusion) or a string `world` denoting use of world coordinates.
     - Returns the sketch profiles or an empty dict if there are no profiles. Note that profile uuid returned is only valid while the design does not change.
 - `close_profile(sketch_name)`: Close the current set of lines to create one or more profiles by joining the first point to the last point
     - `sketch_name`: is the string name of the sketch returned by `add_sketch()`

--- a/tools/fusion360gym/client/fusion_360_client.py
+++ b/tools/fusion360gym/client/fusion_360_client.py
@@ -162,14 +162,16 @@ class Fusion360Client():
         pt_is_dict = isinstance(pt, dict)
         if not pt_is_dict or "x" not in pt or "y" not in pt:
             return self.__return_error(f"Invalid pt value")
-        pt["z"] = 0.0
+        if "z" not in pt:
+            pt["z"] = 0.0
         pt["type"] = "Point3D"
         command_data = {
             "sketch_name": sketch_name,
             "pt": pt
         }
         if transform is not None:
-            if isinstance(transform, dict):
+            if (isinstance(transform, dict) or
+                    isinstance(transform, str)):
                 command_data["transform"] = transform
         return self.send_command("add_point", data=command_data)
 
@@ -183,9 +185,11 @@ class Fusion360Client():
         pt2_is_dict = isinstance(pt1, dict)
         if not pt2_is_dict or "x" not in pt2 or "y" not in pt2:
             return self.__return_error(f"Invalid pt2 value")
-        pt1["z"] = 0.0
+        if "z" not in pt1:
+            pt1["z"] = 0.0
+        if "z" not in pt2:
+            pt2["z"] = 0.0
         pt1["type"] = "Point3D"
-        pt2["z"] = 0.0
         pt2["type"] = "Point3D"
         command_data = {
             "sketch_name": sketch_name,
@@ -193,7 +197,8 @@ class Fusion360Client():
             "pt2": pt2
         }
         if transform is not None:
-            if isinstance(transform, dict):
+            if (isinstance(transform, dict) or
+                    isinstance(transform, str)):
                 command_data["transform"] = transform
         return self.send_command("add_line", data=command_data)
 


### PR DESCRIPTION
This PR adds support to specify sketch and line points in world coords using the `transform="world"`.
For example: `add_point("Sketch1", pt, transform="world")`