### PR TITLE
Add multiple extrude to target face

### DIFF
--- a/tools/fusion360gym/README.md
+++ b/tools/fusion360gym/README.md
@@ -127,6 +127,23 @@ Reconstruct from a target design using extrude operations from face to face.
     - `end_face`: is the uuid of the end face in the target
     - `operation`: a string with the values defining the type of extrude: `JoinFeatureOperation`, `CutFeatureOperation`, `IntersectFeatureOperation`, or `NewBodyFeatureOperation`.
     - Returns a face adjacency graph representing the B-Rep geometry/topology as described [here](../regraph), and an intersection over union value calculated between the target and the reconstruction.
+- `add_extrudes_by_target_face(actions, revert)`: Executes multiple extrude operations, between two faces of the target, in sequence.
+    - `actions`: A list of actions in the following format:
+    ```json
+    [
+        {
+            "start_face": "7f00f7de-ee2e-11ea-adc1-0242ac120002",
+            "end_face": "89b53186-ee2e-11ea-adc1-0242ac120002",
+            "operation": "NewBodyFeatureOperation"
+        },
+        {
+            "start_face": "b4982e94-ee2e-11ea-adc1-0242ac120002",
+            "end_face": "b98cebe2-ee2e-11ea-adc1-0242ac120002",
+            "operation": "JoinFeatureOperation"
+        }
+    ]
+    ```
+    - `revert`: Revert to the target design before executing the extrude actions.
 
 #### Export
 Export the existing design in a number of formats.
@@ -153,11 +170,11 @@ Various utility calls to interact with Fusion 360.
 - `detach()`: Detach the server from Fusion, taking it offline, allowing the Fusion UI to become responsive again 
 - `commands(command_list, dir)`: Send a list of commands to run in sequence on the server. Currently the export and reconstruction commands are supported.
     - `command_list`: a list of commands in the following format:
-    ```
+    ```json
     [
         {
             "command": "reconstruct",
-            "data": json_data
+            "data": {}
         },
         {
             "command": "sketches",

--- a/tools/fusion360gym/client/fusion_360_client.py
+++ b/tools/fusion360gym/client/fusion_360_client.py
@@ -253,6 +253,32 @@ class Fusion360Client():
         }
         return self.send_command("add_extrude_by_target_face", command_data)
 
+    def add_extrudes_by_target_face(self, actions, revert=False):
+        """Executes multiple extrude operations,
+            between two faces of the target, in sequence"""
+        if (actions is None or not isinstance(actions, list) or
+           len(actions) == 0):
+            return self.__return_error(f"Invalid actions")
+        for action in actions:
+            if ("start_face" not in action or
+                    "end_face" not in action or
+                    "operation" not in action):
+                return self.__return_error(f"Invalid actions")
+            start_face = action["start_face"]
+            end_face = action["end_face"]
+            operation = action["operation"]
+            if not isinstance(start_face, str) or len(start_face) == 0:
+                return self.__return_error(f"Invalid start_face value")
+            if not isinstance(end_face, str) or len(end_face) == 0:
+                return self.__return_error(f"Invalid end_face value")
+            if operation not in self.feature_operations:
+                return self.__return_error(f"Invalid operation value")
+        command_data = {
+            "actions": actions,
+            "revert": revert
+        }
+        return self.send_command("add_extrudes_by_target_face", command_data)
+
     # -------------------------------------------------------------------------
     # EXPORT
     # -------------------------------------------------------------------------

--- a/tools/fusion360gym/server/command_runner.py
+++ b/tools/fusion360gym/server/command_runner.py
@@ -61,7 +61,7 @@ class CommandRunner():
             elif command == "screenshot":
                 result = self.export.screenshot(data)
             elif command == "graph":
-                result = self.export.graph(data)                
+                result = self.export.graph(data)
             elif command == "commands":
                 result = self.export.commands(data)
             elif command == "add_sketch":
@@ -77,9 +77,11 @@ class CommandRunner():
             elif command == "set_target":
                 result = self.target.set_target(data)
             elif command == "revert_to_target":
-                result = self.target.revert_to_target(data)                
+                result = self.target.revert_to_target()
             elif command == "add_extrude_by_target_face":
                 result = self.target.add_extrude_by_target_face(data)
+            elif command == "add_extrudes_by_target_face":
+                result = self.target.add_extrudes_by_target_face(data)
             else:
                 return self.return_failure("Unknown command")
             return result

--- a/tools/search/repl_env.py
+++ b/tools/search/repl_env.py
@@ -58,6 +58,28 @@ class ReplEnv(GymEnv):
                 return_iou = response_json["data"]["iou"]
         return return_graph, return_iou
 
+    def extrudes(self, actions, revert=False):
+        """Extrudes wrapper around the gym client"""
+        is_invalid = False
+        return_graph = None
+        return_iou = None
+        action_arg = []
+        for action in actions:
+            action_arg.append({
+                "start_face": action[0],
+                "end_face": action[1],
+                "operation": action[2]
+            })
+        r = self.client.add_extrudes_by_target_face(action_arg, revert)
+        if r is not None and r.status_code == 200:
+            response_json = r.json()
+            if ("data" in response_json and
+                    "graph" in response_json["data"] and
+                    "iou" in response_json["data"]):
+                return_graph = response_json["data"]["graph"]
+                return_iou = response_json["data"]["iou"]
+        return return_graph, return_iou
+
     def screenshot(self, file):
         """Save out a screenshot"""
         r = self.client.screenshot(file)


### PR DESCRIPTION
This PR adds the `add_extrudes_by_target_face()` call to Fusion Gym.
This can be used to specify multiple extrude operations in a single call.
@evanthebouncy 