### PR TITLE
Add arc/circle support to gym

### DIFF
--- a/tools/fusion360gym/README.md
+++ b/tools/fusion360gym/README.md
@@ -148,16 +148,31 @@ Incrementally create designs by generating the underlying sketch primitives and 
         - B-Rep planar face id
         - point3d on a planar face of a B-Rep
     - Returns the `sketch_name` and `sketch_id`.
-- `add_point(sketch_name, p1, transform)`: Add a point to create a new sequential line in the given sketch
+- `add_point(sketch_name, p, transform)`: Add a point to create a new sequential line in the given sketch
     - `sketch_name`: is the string name of the sketch returned by `add_sketch()`
-    - `p1`: a point in sketch space 2D coords in a dict e.g. `{"x": 0, "y": 0}` or 3D coords if `transform="world"` is specified, indicating use of world coords
+    - `p`: a point in sketch space 2D coords in a dict e.g. `{"x": 0, "y": 0}` or 3D coords if `transform="world"` is specified, indicating use of world coords
     - `transform` (optional): the transform for the sketch (necessary if you are replaying json data exported from Fusion) or a string `world` denoting use of world coordinates.
     - Returns the sketch `profiles` or an empty dict if there are no `profiles`. Note that profile uuid returned is only valid while the design does not change.
 - `add_line(sketch_name, p1, p2, transform)`: Adds a line to the given sketch. 
     - `sketch_name`: is the string name of the sketch returned by `add_sketch()`
-    - `p1` and `p2`: are sketch space 2D coords of the line in a dict e.g. `{"x": 0, "y": 0}` or 3D coords if `transform="world"` is specified, indicating use of world coords
+    - `p1`: Start point. Passed in sketch space 2D coords of the line in a dict e.g. `{"x": 0, "y": 0}` or 3D coords if `transform="world"` is specified, indicating use of world coords.
+    - `p2`: End point. Passed in sketch space 2D coords of the line in a dict e.g. `{"x": 0, "y": 0}` or 3D coords if `transform="world"` is specified, indicating use of world coords.
     - `transform` (optional): the transform for the sketch (necessary if you are replaying json data exported from Fusion) or a string `world` denoting use of world coordinates.
     - Returns the sketch profiles or an empty dict if there are no profiles. Note that profile uuid returned is only valid while the design does not change.
+- `add_arc(sketch_name, p1, p2, angle, transform)`: Adds an arc to the given sketch. 
+    - `sketch_name`: is the string name of the sketch returned by `add_sketch()`
+    - `p1`: Start point of the arc. Passed in sketch space 2D coords of the line in a dict e.g. `{"x": 0, "y": 0}` or 3D coords if `transform="world"` is specified, indicating use of world coords.
+    - `p2`: Center point of the arc. Passed in sketch space 2D coords of the line in a dict e.g. `{"x": 0, "y": 0}` or 3D coords if `transform="world"` is specified, indicating use of world coords.
+    - `angle`: The sweep angle of the arc. This is defined in degrees with a positive value creating a counter-clockwise sweep.
+    - `transform` (optional): the transform for the sketch (necessary if you are replaying json data exported from Fusion) or a string `world` denoting use of world coordinates.
+    - Returns the sketch profiles or an empty dict if there are no profiles. Note that profile uuid returned is only valid while the design does not change.
+- `add_circle(sketch_name, p, radius, transform)`: Adds a circle to the given sketch. 
+    - `sketch_name`: is the string name of the sketch returned by `add_sketch()`
+    - `p`: Center point of the circle. Passed in sketch space 2D coords of the line in a dict e.g. `{"x": 0, "y": 0}` or 3D coords if `transform="world"` is specified, indicating use of world coords.
+    - `radius`: The radius of the circle.
+    - `transform` (optional): the transform for the sketch (necessary if you are replaying json data exported from Fusion) or a string `world` denoting use of world coordinates.
+    - Returns the sketch profiles or an empty dict if there are no profiles. Note that profile uuid returned is only valid while the design does not change.    
+
 - `close_profile(sketch_name)`: Close the current set of lines to create one or more profiles by joining the first point to the last point
     - `sketch_name`: is the string name of the sketch returned by `add_sketch()`
 - `add_extrude(sketch_name, profile_id, distance, operation)`: Add an extrude to the design

--- a/tools/fusion360gym/client/fusion360gym_client.py
+++ b/tools/fusion360gym/client/fusion360gym_client.py
@@ -180,9 +180,8 @@ class Fusion360GymClient():
             command_data["rotate"] = rotate
         return self.send_command("reconstruct_curve", data=command_data)
 
-
     def reconstruct_curves(self, sketch_data, sketch_name,
-                          scale=None, translate=None, rotate=None):
+                           scale=None, translate=None, rotate=None):
         """Reconstruct all curves from the provided
             sketch data and sketch name"""
         if not isinstance(sketch_data, dict) or not sketch_data:
@@ -267,7 +266,7 @@ class Fusion360GymClient():
         pt1_is_dict = isinstance(pt1, dict)
         if not pt1_is_dict or "x" not in pt1 or "y" not in pt1:
             return self.__return_error(f"Invalid pt1 value")
-        pt2_is_dict = isinstance(pt1, dict)
+        pt2_is_dict = isinstance(pt2, dict)
         if not pt2_is_dict or "x" not in pt2 or "y" not in pt2:
             return self.__return_error(f"Invalid pt2 value")
         if "z" not in pt1:
@@ -286,6 +285,61 @@ class Fusion360GymClient():
                     isinstance(transform, str)):
                 command_data["transform"] = transform
         return self.send_command("add_line", data=command_data)
+
+    def add_arc(self, sketch_name, pt1, pt2, angle, transform=None):
+        """Add an arc to the given sketch"""
+        if not isinstance(sketch_name, str):
+            return self.__return_error(f"Invalid sketch_name")
+        pt1_is_dict = isinstance(pt1, dict)
+        if not pt1_is_dict or "x" not in pt1 or "y" not in pt1:
+            return self.__return_error(f"Invalid pt1 value")
+        pt2_is_dict = isinstance(pt2, dict)
+        if not pt2_is_dict or "x" not in pt2 or "y" not in pt2:
+            return self.__return_error(f"Invalid pt2 value")
+        if "z" not in pt1:
+            pt1["z"] = 0.0
+        if "z" not in pt2:
+            pt2["z"] = 0.0
+        pt1["type"] = "Point3D"
+        pt2["type"] = "Point3D"
+        is_number = isinstance(angle, float) or isinstance(angle, int)
+        if not is_number:
+            return self.__return_error(f"Invalid angle")
+        command_data = {
+            "sketch_name": sketch_name,
+            "pt1": pt1,
+            "pt2": pt2,
+            "angle": angle
+        }
+        if transform is not None:
+            if (isinstance(transform, dict) or
+                    isinstance(transform, str)):
+                command_data["transform"] = transform
+        return self.send_command("add_arc", data=command_data)
+
+    def add_circle(self, sketch_name, pt1, radius, transform=None):
+        """Add a circle to the given sketch"""
+        if not isinstance(sketch_name, str):
+            return self.__return_error(f"Invalid sketch_name")
+        pt1_is_dict = isinstance(pt1, dict)
+        if not pt1_is_dict or "x" not in pt1 or "y" not in pt1:
+            return self.__return_error(f"Invalid pt1 value")
+        if "z" not in pt1:
+            pt1["z"] = 0.0
+        pt1["type"] = "Point3D"
+        is_number = isinstance(radius, float) or isinstance(radius, int)
+        if not is_number:
+            return self.__return_error(f"Invalid radius")
+        command_data = {
+            "sketch_name": sketch_name,
+            "pt1": pt1,
+            "radius": radius
+        }
+        if transform is not None:
+            if (isinstance(transform, dict) or
+                    isinstance(transform, str)):
+                command_data["transform"] = transform
+        return self.send_command("add_circle", data=command_data)
 
     def close_profile(self, sketch_name):
         """Close the current set of lines to create one or more profiles
@@ -323,7 +377,7 @@ class Fusion360GymClient():
     # -------------------------------------------------------------------------
 
     def set_target(self, file):
-        """Set the target that we want to reconstruct with a .step or .smt file.
+        """Set the target that we want to reconstruct with a .step or .smt file
             This call will clear the current design"""
         if isinstance(file, str):
             file = Path(file)
@@ -466,7 +520,7 @@ class Fusion360GymClient():
             curve_counts.append(curve_count)
             sketch_areas.append(sketch_area)
         # calculate distributions
-        plane_distribution = [[],[]]
+        plane_distribution = [[], []]
         for plane in plane_counts:
             plane_distribution[0].append(plane)
             plane_distribution[1].append(plane_counts[plane] / sum(plane_counts.values()))
@@ -477,14 +531,16 @@ class Fusion360GymClient():
         body_distribution = self.__get_per_distribution(body_counts, 0, 11, 11, True)
         sketch_area_distribution = self.__get_per_distribution(sketch_areas, 0, 500, 25)
         profile_area_distribution = self.__get_per_distribution(profile_areas, 0, 100, 25)
-        distributions = {"sketch_plane": plane_distribution,
-                        "num_faces": face_distribution,
-                        "num_extrusions": extrusion_distribution, 
-                        "length_sequences": sequence_distribution,
-                        "num_curves": curve_distribution,
-                        "num_bodies": body_distribution,
-                        "sketch_areas": sketch_area_distribution,
-                        "profile_areas": profile_area_distribution}
+        distributions = {
+            "sketch_plane": plane_distribution,
+            "num_faces": face_distribution,
+            "num_extrusions": extrusion_distribution,
+            "length_sequences": sequence_distribution,
+            "num_curves": curve_distribution,
+            "num_bodies": body_distribution,
+            "sketch_areas": sketch_area_distribution,
+            "profile_areas": profile_area_distribution
+        }
         return distributions
 
     def get_distributions_from_json(self, file):
@@ -508,7 +564,11 @@ class Fusion360GymClient():
         sampled_parameters = {}
         if parameters is None:
             for key in distributions:
-                sampled_parameters[key] = np.random.choice(distributions[key][0], 1, p=distributions[key][1])[0]
+                sampled_parameters[key] = np.random.choice(
+                    distributions[key][0],
+                    1,
+                    p=distributions[key][1]
+                )[0]
             return sampled_parameters
         else:
             if not isinstance(parameters, list):
@@ -516,7 +576,11 @@ class Fusion360GymClient():
             for parameter in parameters:
                 if parameter not in self.distribution_categories:
                     return self.__return_error(f"Invalid parameters")
-                sampled_parameters[parameter] = np.random.choice(distributions[parameter][0], 1, p=distributions[parameter][1])[0]
+                sampled_parameters[parameter] = np.random.choice(
+                    distributions[parameter][0],
+                    1,
+                    p=distributions[parameter][1]
+                )[0]
             return sampled_parameters
 
     def sample_design(self, data_dir, filter=True, split_file=None):
@@ -581,7 +645,7 @@ class Fusion360GymClient():
         """sample profiles from the provided sketch"""
         if not isinstance(sketch_data, dict) or not sketch_data:
             return self.__return_error("Sketch data is invalid")
-        if not "profiles" in sketch_data:
+        if "profiles" not in sketch_data:
             return self.__return_error("No profile data in the sketch")
         profiles = sketch_data["profiles"]
         if not isinstance(max_number_profiles, int) or max_number_profiles < 1:
@@ -590,8 +654,9 @@ class Fusion360GymClient():
             num_sampled_profiles = max_number_profiles
         else:
             num_sampled_profiles = len(profiles)
-        if not sampling_type == "random" and not sampling_type == "deterministic" and \
-            not sampling_type == "distributive":
+        if not sampling_type == "random" and \
+           not sampling_type == "deterministic" and \
+           not sampling_type == "distributive":
             return self.__return_error("Invalid sampling type")
         if sampling_type == "random":
             profile_objects = list(profiles.values())
@@ -610,7 +675,7 @@ class Fusion360GymClient():
                 if profile_areas[profile_id] >= average_area:
                     filtered_profile_areas[profile_id] = profile_areas[profile_id]
             sorted_profile_areas = {k: v for k, v in sorted(filtered_profile_areas.items(), key=lambda item: item[1], reverse=True)}
-            # retrun the sampled profiles 
+            # retrun the sampled profiles
             sampled_profiles = []
             index = 0
             for profile_id in sorted_profile_areas:
@@ -630,7 +695,7 @@ class Fusion360GymClient():
                 profile_areas[profile_id] = profile_object["properties"]["area"]
                 if profile_object["properties"]["area"] > sampled_area:
                     filtered_profile_areas[profile_id] = profile_object["properties"]["area"]
-            # if no qualified profiles, sample the profiles in descending order 
+            # if no qualified profiles, sample the profiles in descending order
             if len(filtered_profile_areas) > 0:
                 sorted_profile_areas = {k: v for k, v in sorted(filtered_profile_areas.items(), key=lambda item: item[1], reverse=True)}
             else:
@@ -673,7 +738,7 @@ class Fusion360GymClient():
         return json_files
 
     def __get_per_distribution(self, data, range_min, range_max, num_bins, shift=False):
-        np_counts, np_bins = np.histogram(data, num_bins, range=(range_min,range_max))
+        np_counts, np_bins = np.histogram(data, num_bins, range=(range_min, range_max))
         if not shift:
             np_bins = np.delete(np_bins, 0)
         else:

--- a/tools/fusion360gym/client/fusion360gym_client.py
+++ b/tools/fusion360gym/client/fusion360gym_client.py
@@ -332,7 +332,7 @@ class Fusion360GymClient():
             return self.__return_error(f"Invalid radius")
         command_data = {
             "sketch_name": sketch_name,
-            "pt1": pt1,
+            "pt": pt1,
             "radius": radius
         }
         if transform is not None:

--- a/tools/fusion360gym/server/.env
+++ b/tools/fusion360gym/server/.env
@@ -1,0 +1,1 @@
+PYTHONPATH=/Users/willisk/Library/Application Support/Autodesk/webdeploy/production/c2e0b54e6b4482abc34cb131ac8f668cd49da7ca/Api/Python/packages

--- a/tools/fusion360gym/server/command_runner.py
+++ b/tools/fusion360gym/server/command_runner.py
@@ -64,7 +64,7 @@ class CommandRunner():
             elif command == "reconstruct_curve":
                 result = self.reconstruct.reconstruct_curve(data)
             elif command == "reconstruct_curves":
-                result = self.reconstruct.reconstruct_curves(data)                
+                result = self.reconstruct.reconstruct_curves(data)
             elif command == "clear":
                 result = self.design_state.clear()
             elif command == "mesh":
@@ -83,6 +83,10 @@ class CommandRunner():
                 result = self.sketch_extrusion.add_point(data)
             elif command == "add_line":
                 result = self.sketch_extrusion.add_line(data)
+            elif command == "add_arc":
+                result = self.sketch_extrusion.add_arc(data)
+            elif command == "add_circle":
+                result = self.sketch_extrusion.add_circle(data)
             elif command == "close_profile":
                 result = self.sketch_extrusion.close_profile(data)
             elif command == "add_extrude":

--- a/tools/fusion360gym/server/command_sketch_extrusion.py
+++ b/tools/fusion360gym/server/command_sketch_extrusion.py
@@ -252,7 +252,7 @@ class CommandSketchExtrusion(CommandBase):
             start_point,
             angle_radians
         )
-        end_point = serialize.point3d(arc.endSketchPoint)
+        end_point = serialize.point3d(arc.endSketchPoint.geometry)
         curve_uuid = name.set_uuid(arc)
         name.set_uuids_for_sketch(sketch)
         profile_data = serialize.sketch_profiles(sketch.profiles)
@@ -268,7 +268,7 @@ class CommandSketchExtrusion(CommandBase):
         })
 
     def __add_circle(self, sketch, sketch_uuid, pt1, radius, transform=None):
-        center_point = deserialize.point3d(pt2)
+        center_point = deserialize.point3d(pt1)
         if transform is not None:
             if isinstance(transform, str):
                 # Transform world coords to sketch coords

--- a/tools/fusion360gym/test/README.md
+++ b/tools/fusion360gym/test/README.md
@@ -3,7 +3,7 @@ Tests use the [Python Unit testing framework](https://docs.python.org/3/library/
 
 
 ## Visual Studio Code Setup
-Tests can be setup and run from [Visual Studio Code](https://code.visualstudio.com/docs/python/testing) by adding the following to the `settings.json` folder at the root of the repo.
+Tests can be setup and run from [Visual Studio Code](https://code.visualstudio.com/docs/python/testing) by adding the following to the `settings.json` file in the `.vscode/` folder at the root of the repo.
 
 ```json
 {
@@ -23,7 +23,7 @@ Tests can be setup and run from [Visual Studio Code](https://code.visualstudio.c
 
 
 ## Test Config File
-To run all tests reqyures a `test_config.json` file, in the test directory, to store the path to the dataset, required by some tests. The contents of that file are as follows:
+To run all tests requires a `test_config.json` file, in the test directory, to store the path to the dataset, required by some tests. The contents of that file are as follows:
 
 ```json
 {

--- a/tools/fusion360gym/test/test_fusion360gym_sketch_extrusion.py
+++ b/tools/fusion360gym/test/test_fusion360gym_sketch_extrusion.py
@@ -92,9 +92,6 @@ class TestFusion360ServerSketchExtrusion(unittest.TestCase):
         self.assertIsInstance(response_data["profiles"], dict, msg="add_line profiles are dict")
         self.assertEqual(len(response_data["profiles"]), 0, msg="add_line profiles length equals 0")
 
-        # self.client.clear()
-        # r = self.client.detach()
-
     def test_add_lines(self):
         self.client.clear()
         r = self.client.add_sketch("XY")
@@ -147,6 +144,63 @@ class TestFusion360ServerSketchExtrusion(unittest.TestCase):
 
         # self.client.clear()
         # r = self.client.detach()
+
+    def test_add_circle(self):
+        self.client.clear()
+        r = self.client.add_sketch("XY")
+        response_json = r.json()
+        response_data = response_json["data"]
+        sketch_name = response_data["sketch_name"]
+        pt1 = {"x": 0, "y": 0}
+        r = self.client.add_circle(sketch_name, pt1, 5)
+        self.assertEqual(r.status_code, 200, msg="add_circle status code")
+        response_json = r.json()
+        self.assertIn("data", response_json, msg="add_circle response has data")
+        response_data = response_json["data"]
+        # sketch_id
+        self.assertIn("sketch_id", response_data, msg="add_circle response has sketch_id")
+        self.assertIsInstance(response_data["sketch_id"], str, msg="add_circle sketch_id is string")
+        # sketch_name
+        self.assertIn("sketch_name", response_data, msg="add_circle response has sketch_name")
+        self.assertIsInstance(response_data["sketch_name"], str, msg="add_circle sketch_name is string")
+        # curve_id
+        self.assertIn("curve_id", response_data, msg="add_circle response has curve_id")
+        self.assertIsInstance(response_data["curve_id"], str, msg="add_circle curve_id is string")
+        self.assertEqual(len(response_data["curve_id"]), 36, msg="add_circle curve_id length equals 36")
+        # profiles
+        self.assertIn("profiles", response_data, msg="add_circle response has profiles")
+        self.assertIsInstance(response_data["profiles"], dict, msg="add_circle profiles are dict")
+        self.assertEqual(len(response_data["profiles"]), 1, msg="add_circle profiles length equals 1")
+
+    def test_add_arc(self):
+        self.client.clear()
+        r = self.client.add_sketch("XY")
+        response_json = r.json()
+        response_data = response_json["data"]
+        sketch_name = response_data["sketch_name"]
+        # Start of arc
+        pt1 = {"x": 10, "y": 0}
+        # Center of arc
+        pt2 = {"x": 0, "y": 0} 
+        r = self.client.add_arc(sketch_name, pt1, pt2, 90)
+        self.assertEqual(r.status_code, 200, msg="add_arc status code")
+        response_json = r.json()
+        self.assertIn("data", response_json, msg="add_arc response has data")
+        response_data = response_json["data"]
+        # sketch_id
+        self.assertIn("sketch_id", response_data, msg="add_arc response has sketch_id")
+        self.assertIsInstance(response_data["sketch_id"], str, msg="add_arc sketch_id is string")
+        # sketch_name
+        self.assertIn("sketch_name", response_data, msg="add_arc response has sketch_name")
+        self.assertIsInstance(response_data["sketch_name"], str, msg="add_arc sketch_name is string")
+        # curve_id
+        self.assertIn("curve_id", response_data, msg="add_arc response has curve_id")
+        self.assertIsInstance(response_data["curve_id"], str, msg="add_arc curve_id is string")
+        self.assertEqual(len(response_data["curve_id"]), 36, msg="add_arc curve_id length equals 36")
+        # profiles
+        self.assertIn("profiles", response_data, msg="add_arc response has profiles")
+        self.assertIsInstance(response_data["profiles"], dict, msg="add_arc profiles are dict")
+        self.assertEqual(len(response_data["profiles"]), 0, msg="add_arc profiles length equals 0")
 
     def test_add_extrude(self):
         self.client.clear()


### PR DESCRIPTION
This PR add support for creating arcs and circles with commands below:

- `add_arc(sketch_name, p1, p2, angle, transform)`: Adds an arc to the given sketch. 
    - `sketch_name`: is the string name of the sketch returned by `add_sketch()`
    - `p1`: Start point of the arc. Passed in sketch space 2D coords of the line in a dict e.g. `{"x": 0, "y": 0}` or 3D coords if `transform="world"` is specified, indicating use of world coords.
    - `p2`: Center point of the arc. Passed in sketch space 2D coords of the line in a dict e.g. `{"x": 0, "y": 0}` or 3D coords if `transform="world"` is specified, indicating use of world coords.
    - `angle`: The sweep angle of the arc. This is defined in degrees with a positive value creating a counter-clockwise sweep.
    - `transform` (optional): the transform for the sketch (necessary if you are replaying json data exported from Fusion) or a string `world` denoting use of world coordinates.
    - Returns the sketch profiles or an empty dict if there are no profiles. Note that profile uuid returned is only valid while the design does not change.
- `add_circle(sketch_name, p, radius, transform)`: Adds a circle to the given sketch. 
    - `sketch_name`: is the string name of the sketch returned by `add_sketch()`
    - `p`: Center point of the circle. Passed in sketch space 2D coords of the line in a dict e.g. `{"x": 0, "y": 0}` or 3D coords if `transform="world"` is specified, indicating use of world coords.
    - `radius`: The radius of the circle.
    - `transform` (optional): the transform for the sketch (necessary if you are replaying json data exported from Fusion) or a string `world` denoting use of world coordinates.
    - Returns the sketch profiles or an empty dict if there are no profiles. Note that profile uuid returned is only valid while the design does not change.    