### PR TITLE
Fix meshplot `offline` setting in segmentation viewer

### DIFF
--- a/tools/segmentation_viewer/segmentation_viewer.py
+++ b/tools/segmentation_viewer/segmentation_viewer.py
@@ -71,7 +71,7 @@ class SegmentationViewer:
             print(f"The data for {file_stem} could not be loaded.  Skipping")
             return   
         output_pathname = output_folder / (file_stem + ".html")
-        mp.offline()
+        mp.website()
         p = mp.plot(v, f, c=facet_colors)
         p.save(str(output_pathname))
 


### PR DESCRIPTION
Running `segmentation_viewer.py` as instructed in the readme file,

```python
python -m tools.segmentation_viewer.segmentation_viewer \
   --meshes_folder s1.0.0/meshes                        \                      
   --output_folder ./tmp
```

causes two html plots to be generated for each example:

```
Plot saved to file 0534717d-d1e4-4bd4-bca4-5668781708a0.html.
Plot saved to file tmp/83226_3e4d1716_0.html.
Plot saved to file bdaadfe1-6811-4a61-8f96-1f1b558c9871.html.
Plot saved to file tmp/21901_64acc24c_8.html.
Plot saved to file 06b0dfd4-bda3-44fc-910b-63cb2c534e76.html.
Plot saved to file tmp/21900_760d2078_21.html.
...
```

This is because `meshplot.plot` creates an additional html file when in "offline" mode, see [here.](https://github.com/skoch9/meshplot/blob/725e4a7926a5f10888f0edd1762fecf9db751c56/meshplot/plot.py#L96)

This PR fixes that by calling `mp.website()` instead of `mp.offline()`.